### PR TITLE
Logrotate msvc minimal kjell input 2

### DIFF
--- a/logrotate/src/LogRotateUtility.cpp
+++ b/logrotate/src/LogRotateUtility.cpp
@@ -174,6 +174,25 @@ namespace  LogRotateUtility {
       }
    }
 
+    std::map<long, std::string> getLogFilesInDirectory(const std::string& dir, const std::string& app_name) {
+        std::map<long, std::string> files;
+        boost::filesystem::path dir_path(dir);
+  
+ 
+       boost::filesystem::directory_iterator end_itr;
+       if (!boost::filesystem::exists(dir_path)) return {};
+ 
+       for (boost::filesystem::directory_iterator itr(dir_path); itr != end_itr; ++itr) {
+          std::string current_file(itr->path().filename().c_str());
+          long time = 0;
+          if (getDateFromFileName(app_name, current_file, time)) {
+             files.insert(std::pair<long, std::string > (time, current_file));
+          }
+       }
+ 
+       return files;
+    }
+
 
    /// create the file name
    std::string createLogFileName(const std::string& verified_prefix) {

--- a/logrotate/test/RotateFileTest.cpp
+++ b/logrotate/test/RotateFileTest.cpp
@@ -147,7 +147,7 @@ TEST_F(RotateFileTest, rotateAndExpireOldLogs) {
    logrotate.setMaxLogSize(static_cast<int>(gone.size()));
 
 
-   for (size_t idx = 0; idx < 10; ++idx) {
+   for (size_t idx = 0; idx < 15; ++idx) {
       std::string first_message_in_new_log = "message #" + std::to_string(idx);
       logrotate.save(first_message_in_new_log);
       auto content = ReadContent(logfilename);


### PR DESCRIPTION
this takes care of the missing function. 

If you are on linux you can watch /tmp with 
```
watch ls -alh /tmp
```

Which will show the expiration of the logs in the test